### PR TITLE
Change cc message Routes to RoutingInfo

### DIFF
--- a/cc_messages/desired_messages.go
+++ b/cc_messages/desired_messages.go
@@ -12,6 +12,8 @@ const UnspecifiedHealthCheckType HealthCheckType = "" // backwards-compatibility
 const PortHealthCheckType HealthCheckType = "port"
 const NoneHealthCheckType HealthCheckType = "none"
 
+const CC_HTTP_ROUTES = "http_routes"
+
 type DesireAppRequestFromCC struct {
 	ProcessGuid                 string                        `json:"process_guid"`
 	DropletUri                  string                        `json:"droplet_uri"`
@@ -28,13 +30,34 @@ type DesireAppRequestFromCC struct {
 	DiskMB                      int                           `json:"disk_mb"`
 	FileDescriptors             uint64                        `json:"file_descriptors"`
 	NumInstances                int                           `json:"num_instances"`
-	Routes                      []string                      `json:"routes"`
+	RoutingInfo                 CCRouteInfo                   `json:"routing_info"`
 	AllowSSH                    bool                          `json:"allow_ssh"`
 	LogGuid                     string                        `json:"log_guid"`
 	HealthCheckType             HealthCheckType               `json:"health_check_type"`
 	HealthCheckTimeoutInSeconds uint                          `json:"health_check_timeout_in_seconds"`
 	EgressRules                 []*models.SecurityGroupRule   `json:"egress_rules,omitempty"`
 	ETag                        string                        `json:"etag"`
+}
+
+type CCRouteInfo map[string]*json.RawMessage
+
+type CCHTTPRoutes []CCHTTPRoute
+
+func (r CCHTTPRoutes) CCRouteInfo() (CCRouteInfo, error) {
+	routesJson, err := json.Marshal(r)
+	if err != nil {
+		return nil, err
+	}
+
+	routesPayload := json.RawMessage(routesJson)
+	routingInfo := make(map[string]*json.RawMessage)
+	routingInfo[CC_HTTP_ROUTES] = &routesPayload
+	return routingInfo, nil
+}
+
+type CCHTTPRoute struct {
+	Hostname        string `json: "hostname"`
+	RouteServiceUrl string `json: "route_service_url,omitempty"`
 }
 
 type CCDesiredStateServerResponse struct {

--- a/cc_messages/desired_messages_test.go
+++ b/cc_messages/desired_messages_test.go
@@ -1,0 +1,29 @@
+package cc_messages_test
+
+import (
+	"encoding/json"
+
+	"github.com/cloudfoundry-incubator/runtime-schema/cc_messages"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("CC Messages", func() {
+	Describe("CCHTTPRoutes", func() {
+		It("can convert itself into a CCRouteInfo struct", func() {
+			httpRoutes := cc_messages.CCHTTPRoutes{
+				{Hostname: "route1"},
+				{Hostname: "route2"},
+			}
+
+			expectedJson, err := json.Marshal(httpRoutes)
+			Expect(err).ToNot(HaveOccurred())
+
+			ccRouteInfo, err := httpRoutes.CCRouteInfo()
+			Expect(err).NotTo(HaveOccurred())
+
+			json := ccRouteInfo[cc_messages.CC_HTTP_ROUTES]
+			Expect(string(*json)).To(MatchJSON(expectedJson))
+		})
+	})
+})


### PR DESCRIPTION
This commit removes the `routes` field expected from the Cloud Controller `desired` message and introduces a new field `routing_info`.

The schema of this new field is similar to that of `models.Routes` in that it is a `map[string]*json.RawMessage`. We define a single top-level key, `http_routes`, and an associated struct to marshal the raw JSON into. This enables us to add support for route services as well as paving the way for implementing TCP routes in the Cloud Controller.

@crhino && @utako